### PR TITLE
fix(deferPromise): proper calls for `callback` method

### DIFF
--- a/src/deferPromise.ts
+++ b/src/deferPromise.ts
@@ -8,7 +8,7 @@ export default function deferPromise() {
 
   return {
     then: f => promise.then(f),
-    callback: (err, ...data) => err ? resolve([data]) : reject(err),
+    callback: (err, ...data) => err ? reject(err) : resolve(data),
     promise
   };
 }


### PR DESCRIPTION
There were 2 problems:
- if error present, then should be called `reject` 
- `resolve` wraps `data` in array, but it already is an array