### PR TITLE
Bump Passport Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-telegram-official",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Telegram (not official, just the name) authentication strategy for Passport (https://core.telegram.org/widgets/login)",
   "main": "dist/index.js",
   "umd:main": "dist/index.umd.js",
@@ -55,6 +55,6 @@
   },
   "peerDependencies": {
     "express": "*",
-    "passport": "^0.4.1"
+    "passport": "^0.6.0"
   }
 }


### PR DESCRIPTION
Old passport version had a dependabot issue
- Updates passport to 0.6.0
- Version bump to 2.1.0